### PR TITLE
Makefile.common: Fix typos.

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -1,4 +1,4 @@
-LIBRETRO_COMM_DIR := $(CORE_DIR)/src/main/libretro/libretro-comm
+LIBRETRO_COMM_DIR := $(CORE_DIR)/src/main/libretro/libretro-common
 INCFLAGS := -I$(CORE_DIR)/src/main \
 				-I$(CORE_DIR)/src/main/libretro \
 				-I$(LIBRETRO_COMM_DIR)/include \
@@ -15,7 +15,7 @@ else
 SOURCES_C +=   $(LIBRETRO_COMM_DIR)/file/file_path.c \
 					$(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 					$(LIBRETRO_COMM_DIR)/compat/compat_strcasestr.c \
-					$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c \
+					$(LIBRETRO_COMM_DIR)/encodings/encoding_utf.c
 endif
 
 SOURCES_CXX := \


### PR DESCRIPTION
These typos caused the linux builds to fail.
```
--------------------------------------------------
PATH=/usr/lib/ccache:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
--------------------------------------------------
CLEANUP CMD: make -f Makefile platform=unix -j6 clean
Makefile.common:75: *** missing 'endif'.  Stop.
--------------------------------------------------
BUILD CMD: make -f Makefile platform=unix -j6
Makefile.common:75: *** missing 'endif'.  Stop.
BUILD CMD /home/buildbot/buildbot/linux_x86_64/retrolink.sh ./cannonball_libretro.so
readelf: Error: './cannonball_libretro.so': No such file
readelf: Error: './cannonball_libretro.so': No such file
COPY CMD: cp -v ./cannonball_libretro.so /home/buildbot/buildbot/linux_x86_64/dist/unix//cannonball_libretro.so
cp: cannot stat './cannonball_libretro.so': No such file or directory
```