### PR TITLE
Add 120fps mode. Controls fixes.

### DIFF
--- a/res/config.xml
+++ b/res/config.xml
@@ -37,6 +37,7 @@
          0 = 30    FPS. Optimized Mode       (Slow computers)
          1 = 30/60 FPS. Original Game Mode.  (The original experience)
          2 = 60    FPS. Smooth Mode.         (Full 60fps)
+         3 = 120   FPS. Ultra Smooth Mode.   (Full 120fps)
     -->
     <fps>2</fps>
     

--- a/src/main/engine/audio/osoundint.cpp
+++ b/src/main/engine/audio/osoundint.cpp
@@ -79,6 +79,11 @@ void OSoundInt::tick()
         osound.tick();
         osound.tick();
     }
+    else if (config.fps == 120)
+    {
+        play_queued_sound(); // Process audio commands from main program code
+        osound.tick();
+    }
 }
 
 // ----------------------------------------------------------------------------

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -164,16 +164,18 @@ void Outrun::vint()
     osprites.update_sprites();
     otiles.update_tilemaps(cannonball_mode == MODE_ORIGINAL ? ostats.cur_stage : 0);
 
+    uint8_t coin = oinputs.do_credits();
+    outputs->coin_chute_out(&outputs->chute1, coin == 1);
+    outputs->coin_chute_out(&outputs->chute2, coin == 2);
+
     if (config.fps < 120 || (cannonball::frame & 1))
     {
         opalette.cycle_sky_palette();
         opalette.fade_palette();
         // ... 
         ostats.do_timers();
-        if (cannonball_mode != MODE_TTRIAL) ohud.draw_timer1(ostats.time_counter);
-        uint8_t coin = oinputs.do_credits();
-        outputs->coin_chute_out(&outputs->chute1, coin == 1);
-        outputs->coin_chute_out(&outputs->chute2, coin == 2);
+        if (cannonball_mode != MODE_TTRIAL)
+            ohud.draw_timer1(ostats.time_counter);
         oinitengine.set_granular_position();
     }
 }

--- a/src/main/frontend/config.cpp
+++ b/src/main/frontend/config.cpp
@@ -406,11 +406,21 @@ bool Config::clear_scores()
 void Config::set_fps(int fps)
 {
     video.fps = fps;
-    // Set core FPS to 30fps or 60fps
-    this->fps = video.fps == 0 ? 30 : 60;
+    // Set core FPS to 30fps, 60fps or 120fps
+    if (video.fps == 0)
+        this->fps = 30;
+    else if (video.fps == 3)
+        this->fps = 120;
+    else
+        this->fps = 60;
     
     // Original game ticks sprites at 30fps but background scroll at 60fps
-    tick_fps  = video.fps < 2 ? 30 : 60;
+    if (video.fps == 3)
+        tick_fps = 120;
+    else if (video.fps < 2)
+        tick_fps = 30;
+    else
+        tick_fps = 60;
 
     cannonball::frame_ms = 1000.0 / this->fps;
 

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -363,14 +363,14 @@ void Menu::tick_ui()
     // Shift horizon
     if (oroad.horizon_base > HORIZON_DEST)
     {
-        oroad.horizon_base -= 60 / config.fps;
+        oroad.horizon_base -= 60 / (config.fps < 60 ? config.fps : 60);
         if (oroad.horizon_base < HORIZON_DEST)
             oroad.horizon_base = HORIZON_DEST;
     }
     // Advance road
     else
     {
-        uint32_t scroll_speed = (config.fps == 60) ? config.menu.road_scroll_speed : config.menu.road_scroll_speed << 1;
+        uint32_t scroll_speed = (config.fps >= 60) ? config.menu.road_scroll_speed : config.menu.road_scroll_speed << 1;
 
         if (oinitengine.car_increment < scroll_speed << 16)
             oinitengine.car_increment += (1 << 14);
@@ -389,7 +389,9 @@ void Menu::tick_ui()
     }
 
     // Do Animations at 30 fps
-    if (config.fps != 60 || (frame & 1) == 0)
+    if (config.fps == 30
+        || (config.fps == 60 && (frame & 1) == 0)
+        || (config.fps == 120 && (frame & 3) == 1))
     {
         ologo.tick();
         osprites.sprite_copy();
@@ -645,7 +647,7 @@ void Menu::tick_menu()
             }
             else if (SELECTED(ENTRY_FPS))
             {
-                if (++config.video.fps > 2)
+                if (++config.video.fps > 3)
                 {
 #ifdef __LIBRETRO__
                     config.video.fps = 1;
@@ -860,13 +862,14 @@ void Menu::refresh_menu()
                 set_menu_text(ENTRY_HIRES, config.video.hires ? "ON" : "OFF");
             else if (SELECTED(ENTRY_FPS))
             {               
-                if (config.video.fps == 0)      s = "30 FPS";
 #ifdef __LIBRETRO__
-                else if (config.video.fps == 1) s = "30 FPS";
+                if (config.video.fps == 1) s = "ORIGINAL";
 #else
+                if (config.video.fps == 0)      s = "30 FPS";
                 else if (config.video.fps == 1) s = "ORIGINAL";
 #endif
                 else if (config.video.fps == 2) s = "60 FPS";
+                else if (config.video.fps == 3) s = "120 FPS";
                 set_menu_text(ENTRY_FPS, s);
             }
             else if (SELECTED(ENTRY_SCANLINES))

--- a/src/main/libretro/input.cpp
+++ b/src/main/libretro/input.cpp
@@ -31,7 +31,7 @@ void Input::init(int pad_id, int* key_config, int* pad_config, int analog, int* 
     this->wheel_zone  = analog_settings[0];
     this->wheel_dead  = analog_settings[1];
     this->pedals_dead = analog_settings[2];
-    this->gamepad     = true;
+    this->gamepad     = analog;
 
     a_wheel = CENTRE;
 }

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -52,6 +52,9 @@ Interface cannonboard;
 // Pause Engine
 bool pause_engine;
 
+float FRAMERATE = 60;
+bool timing_update = false;
+
 static void config_init(void)
 {
     // ------------------------------------------------------------------------
@@ -216,11 +219,12 @@ void retro_set_environment(retro_environment_t cb)
       { "cannonball_menu_road_scroll_speed", "Menu Road Scroll Speed; 50|60|70|80|90|100|150|200|300|400|500|5|10|15|20|25|30|40" },
       { "cannonball_video_widescreen", "Video Widescreen Mode; ON|OFF" },
       { "cannonball_video_hires", "Video High-Resolution Mode; OFF|ON" },
-/*      { "cannonball_video_fps", "Video Framerate; Smooth (60)|Original (60/30)|Low (30)" }, */
+      { "cannonball_video_fps", "Video Framerate; Smooth (60)|Ultra Smooth (120)|Original (60/30)" },
       { "cannonball_sound_advertise", "Advertise Sound; ON|OFF" },
       { "cannonball_sound_preview", "Preview Music; ON|OFF" },
       { "cannonball_sound_fix_samples", "Fix Samples (use opr-10188.71f); ON|OFF" },
       { "cannonball_gear", "Gear Mode; Manual|Manual Cabinet|Manual 2 Buttons|Automatic" },
+      { "cannonball_analog", "Analog Controls (off to allow digital speed setup); ON|OFF" },
       { "cannonball_steer_speed", "Digital Steer Speed; 3|4|5|6|7|8|9|1|2" },
       { "cannonball_pedal_speed", "Digital Pedal Speed; 4|5|6|7|8|9|1|2|3" },
       { "cannonball_dip_time", "Time; Easy (80s)|Normal (75s)|Hard (72s)|Very Hard (70s)|Infinite Time" },
@@ -327,28 +331,28 @@ static void update_variables(void)
          geometry_update = true;
       }
    }
-/*
+
    var.key = "cannonball_video_fps";
    var.value = NULL;
 
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
-      int newval = 0;
+      unsigned int newval = 0;
 
-      if (strcmp(var.value, "Smooth (60)") == 0)
-         newval = 2;
-      else if (strcmp(var.value, "riginal (60/30)") == 0)
+      if (strcmp(var.value, "Ultra Smooth (120)") == 0)
+         newval = 3;
+      else if (strcmp(var.value, "Original (60/30)") == 0)
          newval = 1;
-      else if (strcmp(var.value, "Low (30)") == 0)
-         newval = 0;
+      else
+         newval = 2;
 
       if (newval != config.video.fps)
       {
          config.video.fps = newval;
-         geometry_update = true;
+         timing_update = true;
       }
    }
-*/
+
    var.key = "cannonball_sound_advertise";
    var.value = NULL;
 
@@ -397,6 +401,23 @@ static void update_variables(void)
          gear_mode = 3;
 
       config.controls.gear = gear_mode;
+   }
+
+   var.key = "cannonball_analog";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "ON") == 0)
+      {
+         config.controls.analog = 1;
+         input.analog = 1;
+      }
+      else if (strcmp(var.value, "OFF") == 0)
+      {
+         config.controls.analog = 0;
+         input.analog = 0;
+      }
    }
 
    var.key = "cannonball_steer_speed";
@@ -600,9 +621,11 @@ static void update_variables(void)
       video.disable();
       video.init(&roms, &config.video);
       video.sprite_layer->set_x_clip(false);
-/*      config.set_fps(config.video.fps); */
       update_geometry();
    }
+
+   if (timing_update)
+      config.set_fps(config.video.fps);
 }
 
 void retro_get_system_info(struct retro_system_info *info) {
@@ -615,13 +638,22 @@ void retro_get_system_info(struct retro_system_info *info) {
 
 void retro_get_system_av_info(struct retro_system_av_info *info) {
     memset(info, 0, sizeof(*info));
-    info->timing.fps            = 60.0;
+    info->timing.fps            = FRAMERATE;
     info->timing.sample_rate    = 44100;
     info->geometry.base_width   = S16_WIDTH;
     info->geometry.base_height  = S16_HEIGHT;
     info->geometry.max_width    = S16_WIDTH << 1;
     info->geometry.max_height   = S16_WIDTH << 1;
     info->geometry.aspect_ratio = (config.video.widescreen)? 16.0f / 9.0f : 4.0f / 3.0f;
+}
+
+void update_timing(void)
+{
+   struct retro_system_av_info system_av_info;
+   retro_get_system_av_info(&system_av_info);
+   FRAMERATE = (config.fps != 120) ? 60 : 119.95;
+   system_av_info.timing.fps = FRAMERATE;
+   environ_cb(RETRO_ENVIRONMENT_SET_SYSTEM_AV_INFO, &system_av_info);
 }
 
 void retro_set_controller_port_device(unsigned port, unsigned device) {
@@ -843,15 +875,18 @@ static void process_events(void)
    analog_l2 = input_state_cb(0, RETRO_DEVICE_ANALOG,
                      RETRO_DEVICE_INDEX_ANALOG_BUTTON, RETRO_DEVICE_ID_JOYPAD_L2);
 
-   // Fallback to digital to avoid the need of an analog/digital core option
-   if (analog_r2 == 0)
-      analog_r2 = input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B ) ? 0x7FFF : 0;
-   if (analog_l2 == 0)
-      analog_l2 = input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y ) ? 0x7FFF : 0;
-   if (analog_left_x == 0)
+   // Fallback to digital
+   if (config.controls.analog == 1)
    {
-      analog_left_x += input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT ) ? -0x7FFF : 0;
-      analog_left_x += input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT ) ? 0x7FFF : 0;
+      if (analog_r2 == 0)
+         analog_r2 = input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B ) ? 0x7FFF : 0;
+      if (analog_l2 == 0)
+         analog_l2 = input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y ) ? 0x7FFF : 0;
+      if (analog_left_x == 0)
+      {
+         analog_left_x += input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_LEFT ) ? -0x7FFF : 0;
+         analog_left_x += input_state_cb( 0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT ) ? 0x7FFF : 0;
+      }
    }
 
    input.handle_joy_axis(analog_left_x, analog_r2, analog_l2);
@@ -859,9 +894,16 @@ static void process_events(void)
 
 void retro_run(void)
 {
+    struct retro_system_av_info system_av_info;
+    retro_get_system_av_info(&system_av_info);
     bool updated = false;
+
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
         update_variables();
+
+    if ((config.fps == 120 && system_av_info.timing.fps == 60) ||
+        (config.fps != 120 && system_av_info.timing.fps == 119.95))
+        update_timing();
 
     frame++;
 


### PR DESCRIPTION
Added an analog on/off core option after all as you would want to turn it off for the digital directions and pedals speed settings to work.

120fps mode:

Added an option to select it in core options + in-game menu.
Fixed the menu logo speed.
Made sound work (are notes shorten a bit? I'm not sure if that problem is still there.)
Made the fps setting apply during runtime (but it cuts the music until you start a new race).

My G-Sync screen deviates in the 119~120hz range.
Different system_av_info.timing.fps didn't help.
Exact sync option in the throttle menu not helping, default sync with DRC same deal.
Only disabling G-sync in nvidia panel gives me a steady 120hz with no audio popping.
No clue what the deal is.