### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,10 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+#############
+## libretro
+#############
+
+*.so
+*.dll

--- a/src/main/engine/omusic.cpp
+++ b/src/main/engine/omusic.cpp
@@ -34,18 +34,21 @@ OMusic::~OMusic(void)
 // Load Modified Widescreen version of tilemap
 bool OMusic::load_widescreen_map()
 {
+    extern char rom_path[1024];
     int status = 0;
 
     if (tilemap == NULL)
     {
+        std::string tilemap_path = std::string(rom_path) + std::string("res/tilemap.bin");
         tilemap = new RomLoader();
-        status += tilemap->load_binary("res/tilemap.bin");
+        status += tilemap->load_binary(tilemap_path.c_str());
     }
 
     if (tile_patch == NULL)
     {
+        std::string tile_patch_path = std::string(rom_path) + std::string("res/tilepatch.bin");
         tile_patch = new RomLoader();
-        status += tile_patch->load_binary("res/tilepatch.bin");
+        status += tile_patch->load_binary(tile_patch_path.c_str());
     }
 
     return status == 0;

--- a/src/main/romloader.cpp
+++ b/src/main/romloader.cpp
@@ -47,7 +47,7 @@ void RomLoader::unload(void)
     delete[] rom;
 }
 
-int RomLoader::load(const char* filename, const int offset, const int length, const int expected_crc, const uint8_t interleave)
+int RomLoader::load(const char* filename, const int offset, const int length, const uint32_t expected_crc, const uint8_t interleave)
 {
     extern retro_environment_t environ_cb;
     extern char rom_path[1024];
@@ -72,7 +72,7 @@ int RomLoader::load(const char* filename, const int offset, const int length, co
 
     if (expected_crc != result.checksum())
     {
-        log_cb(RETRO_LOG_ERROR, "%s has incorrect checksum. Expected: %.2s, Found: %.2s\n", filename, expected_crc, result.checksum());
+        log_cb(RETRO_LOG_ERROR, "%s has incorrect checksum. Expected: 0x%08x, Found: 0x%08x\n", filename, expected_crc, result.checksum());
     }
 
     // Interleave file as necessary

--- a/src/main/romloader.hpp
+++ b/src/main/romloader.hpp
@@ -27,7 +27,7 @@ public:
     RomLoader();
     ~RomLoader();
     void init(uint32_t);
-    int load(const char* filename, const int offset, const int length, const int expected_crc, const uint8_t mode = NORMAL);
+    int load(const char* filename, const int offset, const int length, const uint32_t expected_crc, const uint8_t mode = NORMAL);
     int load_binary(const char* filename);
     void unload(void);
 


### PR DESCRIPTION
This PR fixes two (relatively) minor issues with the core:

- As a result of https://github.com/libretro/cannonball/commit/bb4524c718f16335c8419f4ce3a5310491de42b6, the core will segfault when loading roms with invalid checksums if frontend logging is enabled. This is because the wrong formatting specifiers are used in a `log_cb()` call. This PR sets the correct formatting specifiers.

- At present, widescreen support is somewhat broken because the core cannot load the `tilemap.bin` and `tilepatch.bin` resource files. This PR ensures that these files are loaded from the core content directory.

Closes #23