### PR TITLE
Enable 'contentless' operation by automatically loading game files from frontend system directory

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -16,7 +16,9 @@ SOURCES_C :=
 
 ifeq ($(STATIC_LINKING),1)
 else
-SOURCES_C +=   $(LIBRETRO_COMM_DIR)/file/file_path.c \
+SOURCES_C += \
+	       $(LIBRETRO_COMM_DIR)/file/file_path.c \
+	       $(LIBRETRO_COMM_DIR)/file/file_path_io.c \
 	       $(LIBRETRO_COMM_DIR)/compat/compat_strl.c \
 	       $(LIBRETRO_COMM_DIR)/compat/compat_snprintf.c \
 	       $(LIBRETRO_COMM_DIR)/compat/compat_posix_string.c \


### PR DESCRIPTION
This PR allows the core to be run in 'contentless' fashion by automatically loading game data from the `cannonball` folder inside the frontend system directory. Game assets (minus rom files) will be installable via the new `Core System Files Downloader` menu (https://github.com/libretro/RetroArch/pull/13524) once this is merged: https://github.com/libretro/libretro-system-files/pull/9

Note that regular `Load Content` operation is unaffected.

This allows the core to be launched via the new `Standalone Cores` menu added here: https://github.com/libretro/RetroArch/pull/13655

![Screenshot_2022-02-22_17-15-50](https://user-images.githubusercontent.com/38211560/155184773-2f9a403b-abf3-4556-a0f6-8554f7985b42.png)

