### PR TITLE
Fix reported video dimensions (retro_get_system_av_info()) + add OpenDingux target to .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/libnx-static.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-mips32.yml'
+
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
@@ -196,4 +200,16 @@ libretro-build-wiiu:
 libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
+    - .core-defs
+
+# OpenDingux Beta
+libretro-build-dingux-odbeta-mips32:
+  extends:
+    - .libretro-dingux-odbeta-mips32-make-default
     - .core-defs

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
 
-# GCW Zero
+# GCW0 (OpenDingux and OpenDingux Beta)
 else ifeq ($(platform), gcw0)
    TARGET := $(TARGET_NAME)_libretro.so
    CC = /opt/gcw0-toolchain/usr/bin/mipsel-linux-gcc
@@ -274,7 +274,7 @@ else ifeq ($(platform), gcw0)
    fpic := -fPIC
    SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
    LDFLAGS += -lrt
-   FLAGS += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+   FLAGS += -DDINGUX -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))

--- a/Makefile.common
+++ b/Makefile.common
@@ -8,7 +8,7 @@ ifneq (,$(findstring msvc200,$(platform)))
 INCFLAGS += -I$(LIBRETRO_COMM_DIR)/include/compat/msvc
 endif
 
-FLAGS := -D__LIBRETRO__
+FLAGS += -D__LIBRETRO__
 #FLAGS += -DCANNONBOARD
 FLAGS += -DCOMPILE_SOUND_CODE
 

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -27,6 +27,10 @@
 #include "frontend/cabdiag.hpp"
 #include "frontend/ttrial.hpp"
 
+#ifdef __LIBRETRO__
+extern void update_geometry();
+#endif
+
 namespace boost {
     namespace algorithm {
 
@@ -648,6 +652,9 @@ void Menu::tick_menu()
             {
                 config.video.widescreen = !config.video.widescreen;
                 restart_video();
+#ifdef __LIBRETRO__
+                update_geometry();
+#endif
             }
             else if (SELECTED(ENTRY_HIRES))
             {
@@ -664,6 +671,9 @@ void Menu::tick_menu()
 
                 restart_video();
                 video.sprite_layer->set_x_clip(false);
+#ifdef __LIBRETRO__
+                update_geometry();
+#endif
             }
             else if (SELECTED(ENTRY_SCALE))
             {

--- a/src/main/libretro/audio.cpp
+++ b/src/main/libretro/audio.cpp
@@ -12,6 +12,7 @@
 ***************************************************************************/
 
 #include <string.h>
+#include <stdlib.h>
 #include "audio.hpp"
 #include "frontend/config.hpp" // fps
 #include "engine/audio/osoundint.hpp"

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -76,7 +76,11 @@ static void config_init(void)
     config.video.scanlines  = 0; // Scanlines
     config.video.fps        = 2; // Default is 60 fps
     config.video.fps_count  = 0; // FPS Counter
+#ifdef DINGUX
+    config.video.widescreen = 0; // Enable Widescreen Mode
+#else
     config.video.widescreen = 1; // Enable Widescreen Mode
+#endif
     config.video.hires      = 0; // Hi-Resolution Mode
     config.video.filtering  = 0; // Open GL Filtering Mode
 
@@ -222,7 +226,11 @@ void retro_set_environment(retro_environment_t cb)
    struct retro_variable variables[] = {
       { "cannonball_menu_enabled", "Menu At Start; ON|OFF" },
       { "cannonball_menu_road_scroll_speed", "Menu Road Scroll Speed; 50|60|70|80|90|100|150|200|300|400|500|5|10|15|20|25|30|40" },
+#ifdef DINGUX
+      { "cannonball_video_widescreen", "Video Widescreen Mode; OFF|ON" },
+#else
       { "cannonball_video_widescreen", "Video Widescreen Mode; ON|OFF" },
+#endif
       { "cannonball_video_hires", "Video High-Resolution Mode; OFF|ON" },
       { "cannonball_video_fps", "Video Framerate; Smooth (60)|Ultra Smooth (120)|Original (60/30)" },
       { "cannonball_sound_advertise", "Advertise Sound; ON|OFF" },
@@ -649,14 +657,28 @@ void retro_get_system_info(struct retro_system_info *info) {
 }
 
 void retro_get_system_av_info(struct retro_system_av_info *info) {
-    memset(info, 0, sizeof(*info));
-    info->timing.fps            = FRAMERATE;
-    info->timing.sample_rate    = 44100;
-    info->geometry.base_width   = S16_WIDTH;
-    info->geometry.base_height  = S16_HEIGHT;
-    info->geometry.max_width    = S16_WIDTH << 1;
-    info->geometry.max_height   = S16_WIDTH << 1;
-    info->geometry.aspect_ratio = (config.video.widescreen)? 16.0f / 9.0f : 4.0f / 3.0f;
+   unsigned scale_factor = config.video.hires ? 2 : 1;
+
+   memset(info, 0, sizeof(*info));
+
+   info->timing.fps            = FRAMERATE;
+   info->timing.sample_rate    = 44100;
+
+   info->geometry.max_width    = S16_WIDTH_WIDE << 1;
+   info->geometry.max_height   = S16_HEIGHT     << 1;
+
+   if (config.video.widescreen)
+   {
+      info->geometry.base_width   = S16_WIDTH_WIDE * scale_factor;
+      info->geometry.base_height  = S16_HEIGHT     * scale_factor;
+      info->geometry.aspect_ratio = 16.0 / 9.0;
+   }
+   else
+   {
+      info->geometry.base_width   = S16_WIDTH  * scale_factor;
+      info->geometry.base_height  = S16_HEIGHT * scale_factor;
+      info->geometry.aspect_ratio = 4.0 / 3.0;
+   }
 }
 
 void update_timing(void)


### PR DESCRIPTION
At present, the `max_width`, `base_width` and `base_height` values reported by `retro_get_system_av_info()` are entirely wrong, since they ignore the current widescreen and high resolution mode settings. This PR fixes the issue, and also ensure that geometry updates are registered when widescreen and high resolution mode settings are changed via the in-game menu.

In addition, the PR:

- Fixes a typo in `Makefile.common` that meant all platform-specific build flags were being ignored...
- Adds OpenDingux build jobs to the `.gitlab-ci.yml` file (the core runs full speed on an RG350M)
- Sets the default widescreen setting to `OFF` on OpenDingux platforms