### PR TITLE
Input improvements

### DIFF
--- a/src/main/engine/oinitengine.cpp
+++ b/src/main/engine/oinitengine.cpp
@@ -287,7 +287,11 @@ void OInitEngine::update_engine()
         ohud.blit_text1(HUD_KPH2);
 
         // Blit High/Low Gear
+#ifdef __LIBRETRO__
+        if (!config.cannonboard.enabled)
+#else
         if (config.controls.gear == config.controls.GEAR_BUTTON && !config.cannonboard.enabled)
+#endif
         {
             if (oinputs.gear)
                 ohud.blit_text_new(9, 26, "H");

--- a/src/main/engine/oinputs.cpp
+++ b/src/main/engine/oinputs.cpp
@@ -189,7 +189,11 @@ void OInputs::do_gear()
     {
         // Manual: Cabinet Shifter
         if (config.controls.gear == config.controls.GEAR_PRESS)
+#ifdef __LIBRETRO__
+            gear = !(input.is_pressed(Input::GEAR1) || input.is_pressed(Input::GEAR2));
+#else
             gear = !input.is_pressed(Input::GEAR1);
+#endif
 
         // Manual: Two Separate Buttons for gears
         else if (config.controls.gear == config.controls.GEAR_SEPARATE)
@@ -203,7 +207,11 @@ void OInputs::do_gear()
         // Manual: Keyboard/Digital Button
         else
         {
+#ifdef __LIBRETRO__
+            if (input.has_pressed(Input::GEAR1) || input.has_pressed(Input::GEAR2))
+#else
             if (input.has_pressed(Input::GEAR1))
+#endif
                 gear = !gear;
         }
     }

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -286,7 +286,11 @@ void Outrun::jump_table(Packet* packet)
         }
         else
         {
-            if (config.controls.haptic && config.controls.analog)
+#ifdef __LIBRETRO__
+            if (config.controls.haptic && game_state == GS_INGAME)
+#else
+            if (config.controls.haptic && config.controls.analog && game_state == GS_INGAME)
+#endif
                 outputs->tick(OOutputs::MODE_FFEEDBACK, oinputs.input_steering);
             else if (config.cannonboard.enabled)
                 outputs->tick(OOutputs::MODE_CABINET, packet->ai1, config.cannonboard.cabinet);

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -1127,6 +1127,9 @@ void Menu::start_game(int mode, int settings)
         config.sound.preview        = 1;
 
         restart_video();
+#ifdef __LIBRETRO__
+        update_geometry();
+#endif
     }
     // Original Settings
     else if (settings == 2)
@@ -1151,6 +1154,9 @@ void Menu::start_game(int mode, int settings)
         config.sound.preview        = 0;
 
         restart_video();
+#ifdef __LIBRETRO__
+        update_geometry();
+#endif
     }
     // Otherwise, use whatever is already setup...
     else

--- a/src/main/libretro/ffeedback.cpp
+++ b/src/main/libretro/ffeedback.cpp
@@ -5,15 +5,153 @@
     See license.txt for more details.
 ***************************************************************************/
 
-#include "ffeedback.hpp"
+#include <string.h>
 
-//-----------------------------------------------------------------------------
-// Dummy Functions for now
-//-----------------------------------------------------------------------------
+#include "ffeedback.hpp"
+#include "frontend/config.hpp"
+
 namespace forcefeedback
 {
-    bool init(int a, int b, int c) { return false; } // Did not initialize
-    void close()                   {}
-    int  set(int x, int f)         { return 0; }
-    bool is_supported()            { return false; } // Not supported
+    static struct retro_rumble_interface rumble = {0};
+    static uint16_t rumble_strength_last        = 0;
+    static bool rumble_active                   = false;
+    static uint16_t rumble_min                  = 0;
+    static uint16_t rumble_step                 = 0;
+    static uint16_t rumble_duration             = 0;
+    static uint16_t rumble_counter              = 0;
+
+    bool init_rumble_interface(retro_environment_t environ_cb)
+    {
+        memset(&rumble, 0, sizeof(struct retro_rumble_interface));
+
+        rumble_strength_last = 0;
+        rumble_active        = false;
+
+        rumble_min           = 0x1999;
+        rumble_step          = (0xFFFF - 0x1999) / 5;
+        rumble_duration      = 500;
+        rumble_counter       = 0;
+
+        if (environ_cb(RETRO_ENVIRONMENT_GET_RUMBLE_INTERFACE, &rumble) &&
+                    rumble.set_rumble_state)
+            return true;
+
+        return false;
+    }
+
+    void deactivate_rumble()
+    {
+        if (!rumble.set_rumble_state || !rumble_active)
+            return;
+
+        rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK, 0);
+        rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, 0);
+
+        rumble_counter       = 0;
+        rumble_strength_last = 0;
+        rumble_active        = false;
+    }
+
+    void update_rumble_interface()
+    {
+        uint16_t frame_ticks = (config.fps == 120) ? 8 : 16;
+
+        if (!rumble.set_rumble_state || !rumble_active)
+            return;
+
+        if (rumble_counter > frame_ticks)
+            rumble_counter -= frame_ticks;
+        else
+        {
+            rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK, 0);
+            rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, 0);
+
+            rumble_counter       = 0;
+            rumble_strength_last = 0;
+            rumble_active        = false;
+        }
+    }
+
+    void update_force_limits(int max_force, int min_force, int force_duration)
+    {
+        max_force = (max_force < 0)      ? 0 : max_force;
+        max_force = (max_force > 0xFFFF) ? 0xFFFF : max_force;
+
+        min_force = (min_force < 0)         ? 0 : min_force;
+        min_force = (min_force > max_force) ? max_force : min_force;
+
+        force_duration = (force_duration < 0) ? 0 : force_duration;
+
+        rumble_min      = min_force;
+        rumble_step     = (max_force - min_force) / 5;
+        rumble_duration = force_duration;
+    }
+
+    bool init(int max_force, int min_force, int force_duration)
+    {
+        if (!rumble.set_rumble_state)
+            return false;
+
+        update_force_limits(max_force, min_force, force_duration);
+        return true;
+    }
+
+    void close()
+    {
+        if (rumble.set_rumble_state && rumble_active)
+        {
+            rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK, 0);
+            rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, 0);
+        }
+
+        rumble_counter       = 0;
+        rumble_strength_last = 0;
+        rumble_active        = false;
+
+        memset(&rumble, 0, sizeof(struct retro_rumble_interface));
+    }
+
+    int set(int xdirection, int force)
+    {
+        uint16_t rumble_strength = 0;
+
+        if (!rumble.set_rumble_state || (rumble_step == 0))
+            return 0;
+
+        /* > xdirection is ignored (used to control
+         *   real motors in a physical cabinet)
+         * > force is a value in the range [0, 5]
+         *   (0: strongest, 5: weakest) */
+        force = (force < 0) ? 0 : force;
+        force = (force > 5) ? 5 : force;
+
+        rumble_strength = rumble_min + ((5 - force) * rumble_step);
+        rumble_strength = (rumble_strength > 0xFFFF) ?
+                0xFFFF : rumble_strength;
+
+        if (rumble_strength != rumble_strength_last)
+        {
+            rumble.set_rumble_state(0, RETRO_RUMBLE_WEAK, rumble_strength);
+            rumble.set_rumble_state(0, RETRO_RUMBLE_STRONG, rumble_strength);
+            rumble_strength_last = rumble_strength;
+        }
+
+        if (rumble_strength > 0)
+        {
+            rumble_counter = rumble_duration;
+            rumble_active  = true;
+        }
+        else
+        {
+            rumble_counter = 0;
+            rumble_active  = false;
+        }
+
+        return 1;
+    }
+
+    bool is_supported()
+    {
+        return !!rumble.set_rumble_state;
+    }
 };

--- a/src/main/libretro/ffeedback.hpp
+++ b/src/main/libretro/ffeedback.hpp
@@ -14,11 +14,18 @@
 
 #pragma once
 
+#include <libretro.h>
+
 //-----------------------------------------------------------------------------
 // Function prototypes 
 //-----------------------------------------------------------------------------
 namespace forcefeedback
 {
+    extern bool init_rumble_interface(retro_environment_t environ_cb);
+    extern void deactivate_rumble();
+    extern void update_rumble_interface();
+    extern void update_force_limits(int max_force, int min_force, int force_duration);
+
     extern bool init(int max_force, int min_force, int force_duration);
     extern void close();
     extern int  set(int xdirection, int force);

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -135,7 +135,7 @@ static void config_init(void)
     config.controls.keyconfig[4]  = 122; /* accelerate */
     config.controls.keyconfig[5]  = 120; /* brake */
     config.controls.keyconfig[6]  = 32; /* gear1 */
-    config.controls.keyconfig[7]  = 32; /* gear2 */
+    config.controls.keyconfig[7]  = 33; /* gear2 */
     config.controls.keyconfig[8]  = 49; /* start */
     config.controls.keyconfig[9]  = 53; /* coin */
     config.controls.keyconfig[10] = 286; /* menu */
@@ -758,9 +758,9 @@ bool retro_load_game(const struct retro_game_info *info)
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_UP,    "Up"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_DOWN,  "Down"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT, "Right"},
-      {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Gear"},
+      {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_X,     "Gear (Lo, 2 Buttons Mode)"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_B,     "Accelerate"},
-      {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Gear"},
+      {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_A,     "Gear (Hi, 2 Buttons Mode)"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_Y,     "Brake"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START, "Start"},
       {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Coin"},
@@ -941,7 +941,7 @@ static struct button_bind binds[] = {
    {122, RETRO_DEVICE_ID_JOYPAD_B},      /* Accelerate */
    {120, RETRO_DEVICE_ID_JOYPAD_Y},      /* Brake */
    {32,  RETRO_DEVICE_ID_JOYPAD_X},      /* Gear 1 */
-   {32,  RETRO_DEVICE_ID_JOYPAD_A},      /* Gear 2 */
+   {33,  RETRO_DEVICE_ID_JOYPAD_A},      /* Gear 2 */
    {49,  RETRO_DEVICE_ID_JOYPAD_START},  /* Start  */
    {53,  RETRO_DEVICE_ID_JOYPAD_SELECT}, /* Coin  */
    {304, RETRO_DEVICE_ID_JOYPAD_L},      /* View  */


### PR DESCRIPTION
This PR makes the following input-related improvements:

- The two 'gear' buttons now have separate mapping (previously, both RetroPad buttons were mapped to the same input). When the `Gear Mode` is set to `Manual 2 Buttons`, RetroPad A now switches to 'hi' gear while B switches to 'lo'. In all other `Gear Mode`s, A and B can be used interchangeably. In addition, the current gear selection is now displayed on the HUD when using all `Gear Mode`s.

- Rumble support has been added. The effective rumble strength can be configured via a new `Haptic Feedback Strength` core option

Finally, one unrelated minor bug has been fixed (noticed while I was working on these changes): the libretro screen geometry is now properly updated when starting a new game via the `Set Enhanced/Original Mode` entries in the `Game Modes` menu.
