### PR TITLE
Move save files to frontend save directory

### DIFF
--- a/src/main/engine/ohiscore.cpp
+++ b/src/main/engine/ohiscore.cpp
@@ -6,7 +6,11 @@
     See license.txt for more details.
 ***************************************************************************/
 
+#ifdef __LIBRETRO__
+#include "lr_setup.hpp"
+#else
 #include "setup.hpp"
+#endif
 #include "main.hpp"
 #include "engine/ohud.hpp"
 #include "engine/oinputs.hpp"

--- a/src/main/engine/outrun.cpp
+++ b/src/main/engine/outrun.cpp
@@ -7,7 +7,11 @@
     See license.txt for more details.
 ***************************************************************************/
 
+#ifdef __LIBRETRO__
+#include "lr_setup.hpp"
+#else
 #include "setup.hpp"
+#endif
 #include "main.hpp"
 #include "trackloader.hpp"
 #include "../utils.hpp"

--- a/src/main/frontend/config.cpp
+++ b/src/main/frontend/config.cpp
@@ -16,7 +16,11 @@
 #include "main.hpp"
 #include "config.hpp"
 #include "globals.hpp"
+#ifdef __LIBRETRO__
+#include "lr_setup.hpp"
+#else
 #include "setup.hpp"
+#endif
 #include "../utils.hpp"
 
 #include "engine/ohiscore.hpp"
@@ -180,18 +184,24 @@ bool Config::clear_scores()
     // Init Default Hiscores
     ohiscore.init_def_scores();
 
-    int clear = 0;
+    bool files_removed = false;
 
     // Remove XML files if they exist
-    clear += remove(std::string(FILENAME_SCORES).append(".xml").c_str());
-    clear += remove(std::string(FILENAME_SCORES).append("_jap.xml").c_str());
-    clear += remove(std::string(FILENAME_TTRIAL).append(".xml").c_str());
-    clear += remove(std::string(FILENAME_TTRIAL).append("_jap.xml").c_str());
-    clear += remove(std::string(FILENAME_CONT).append(".xml").c_str());
-    clear += remove(std::string(FILENAME_CONT).append("_jap.xml").c_str());
+    // remove() returns 0 on success
+    if (!remove(std::string(FILENAME_SCORES).append(".xml").c_str()))
+        files_removed = true;
+    if (!remove(std::string(FILENAME_SCORES).append("_jap.xml").c_str()))
+        files_removed = true;
+    if (!remove(std::string(FILENAME_TTRIAL).append(".xml").c_str()))
+        files_removed = true;
+    if (!remove(std::string(FILENAME_TTRIAL).append("_jap.xml").c_str()))
+        files_removed = true;
+    if (!remove(std::string(FILENAME_CONT).append(".xml").c_str()))
+        files_removed = true;
+    if (!remove(std::string(FILENAME_CONT).append("_jap.xml").c_str()))
+        files_removed = true;
 
-    // remove returns 0 on success
-    return clear == 6;
+    return files_removed;
 }
 
 void Config::set_fps(int fps)

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -13,7 +13,11 @@
 
 #include "main.hpp"
 #include "menu.hpp"
+#ifdef __LIBRETRO__
+#include "lr_setup.hpp"
+#else
 #include "setup.hpp"
+#endif
 #include "../utils.hpp"
 #include "../cannonboard/interface.hpp"
 

--- a/src/main/libretro/lr_setup.hpp
+++ b/src/main/libretro/lr_setup.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+extern char FILENAME_SCORES[1024];
+extern char FILENAME_TTRIAL[1024];
+extern char FILENAME_CONT[1024];

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -23,7 +23,7 @@
 #include "romloader.hpp"
 #include "trackloader.hpp"
 #include "main.hpp"
-#include "setup.hpp"
+#include "lr_setup.hpp"
 #include "engine/outrun.hpp"
 #include "frontend/config.hpp"
 #include "frontend/menu.hpp"
@@ -211,6 +211,10 @@ retro_audio_sample_batch_t         audio_batch_cb;
 static struct retro_system_av_info g_av_info;
 
 char rom_path[1024];
+
+char FILENAME_SCORES[1024];
+char FILENAME_TTRIAL[1024];
+char FILENAME_CONT[1024];
 
 static bool option_visibility_set = false;
 static bool sound_enable_prev     = true;
@@ -856,6 +860,34 @@ static void retro_osd_error_msg(const char *str)
    }
 }
 
+static void retro_build_save_paths(void)
+{
+   const char *save_dir = NULL;
+
+   FILENAME_SCORES[0] = '\0';
+   FILENAME_TTRIAL[0] = '\0';
+   FILENAME_CONT[0] = '\0';
+
+   /* Get frontend save directory
+    * > Use game data directory as a fallback if
+    *   no save directory is defined */
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &save_dir) ||
+         !save_dir)
+      save_dir = rom_path;
+
+   /* Build high score save paths
+    * > Note: These are not 'full' paths;
+    *   suffix + extension are added elsewhere */
+   fill_pathname_join(FILENAME_SCORES, save_dir,
+         "hiscores", sizeof(FILENAME_SCORES));
+
+   fill_pathname_join(FILENAME_TTRIAL, save_dir,
+         "hiscores_timetrial", sizeof(FILENAME_TTRIAL));
+
+   fill_pathname_join(FILENAME_CONT, save_dir,
+         "hiscores_continuous", sizeof(FILENAME_CONT));
+}
+
 bool retro_load_game(const struct retro_game_info *info)
 {
    enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;
@@ -915,6 +947,7 @@ bool retro_load_game(const struct retro_game_info *info)
    }
 
    log_cb(RETRO_LOG_INFO, "Rom directory: %s\n", rom_path);
+   retro_build_save_paths();
 
    bool loaded = roms.load_revb_roms();
 

--- a/src/main/video.cpp
+++ b/src/main/video.cpp
@@ -10,7 +10,11 @@
 ***************************************************************************/
 
 #include "video.hpp"
+#ifdef __LIBRETRO__
+#include "lr_setup.hpp"
+#else
 #include "setup.hpp"
+#endif
 #include "globals.hpp"
 #include "frontend/config.hpp"
 


### PR DESCRIPTION
At present, the core writes its high score save files to the current working directory (i.e. the directory containing the RetroArch executable, or the directory from where the executable was run). This is clearly inappropriate. This PR moves the high score files to the frontend save directory (or the ROM directory itself if no save directory is defined).