### PR TITLE
Add Miyoo target and 30fps mode

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-mips32.yml'
 
+  # OpenDingux (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-arm32.yml'
+
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
@@ -212,4 +216,10 @@ libretro-build-dingux-mips32:
 libretro-build-dingux-odbeta-mips32:
   extends:
     - .libretro-dingux-odbeta-mips32-make-default
+    - .core-defs
+
+# Miyoo
+libretro-build-miyoo-arm32:
+  extends:
+    - .libretro-miyoo-arm32-make-default
     - .core-defs

--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,18 @@ else ifeq ($(platform), gcw0)
    LDFLAGS += -lrt
    FLAGS += -DDINGUX -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 
+# Miyoo
+else ifeq ($(platform), miyoo)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/miyoo/usr/bin/arm-linux-gcc
+   CXX = /opt/miyoo/usr/bin/arm-linux-g++
+   AR = /opt/miyoo/usr/bin/arm-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
+   LDFLAGS += -lrt
+   FLAGS += -DDINGUX -fomit-frame-pointer -flto -ffast-math -mcpu=arm926ej-s
+   FLAGS += -DLOW_FPS
+
 # Windows MSVC 2017 all architectures
 else ifneq (,$(findstring windows_msvc2017,$(platform)))
 

--- a/src/main/frontend/menu.cpp
+++ b/src/main/frontend/menu.cpp
@@ -712,12 +712,11 @@ void Menu::tick_menu()
 #endif
                 if (++config.video.fps > 3)
                 {
-                    config.video.fps = 1;
+                    config.video.fps = 0;
                 }
                 config.set_fps(config.video.fps);
 #ifdef __LIBRETRO__
-                if ((config.fps == 120 && fps_prev != 120) ||
-                    (config.fps != 120 && fps_prev == 120))
+                if (config.fps != fps_prev)
                     update_timing();
                 lr_options::set_frontend_variable(&config.video.fps);
 #endif
@@ -1020,8 +1019,9 @@ void Menu::refresh_menu()
             else if (SELECTED(ENTRY_HIRES))
                 set_menu_text(ENTRY_HIRES, config.video.hires ? "ON" : "OFF");
             else if (SELECTED(ENTRY_FPS))
-            {               
-                if (config.video.fps == 1) s = "ORIGINAL";
+            {
+                if (config.video.fps == 0)      s = "30 FPS";
+                else if (config.video.fps == 1) s = "ORIGINAL";
                 else if (config.video.fps == 2) s = "60 FPS";
                 else if (config.video.fps == 3) s = "120 FPS";
                 set_menu_text(ENTRY_FPS, s);
@@ -1253,8 +1253,7 @@ void Menu::start_game(int mode, int settings)
         restart_video();
 #ifdef __LIBRETRO__
         update_geometry();
-        if ((config.fps == 120 && fps_prev != 120) ||
-            (config.fps != 120 && fps_prev == 120))
+        if (config.fps != fps_prev)
             update_timing();
 
         lr_options::set_frontend_variable(&config.sound.fix_samples);
@@ -1292,8 +1291,7 @@ void Menu::start_game(int mode, int settings)
         restart_video();
 #ifdef __LIBRETRO__
         update_geometry();
-        if ((config.fps == 120 && fps_prev != 120) ||
-            (config.fps != 120 && fps_prev == 120))
+        if (config.fps != fps_prev)
             update_timing();
 
         lr_options::set_frontend_variable(&config.sound.fix_samples);

--- a/src/main/libretro/libretro_core_options.h
+++ b/src/main/libretro/libretro_core_options.h
@@ -131,6 +131,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
       NULL,
       "video",
       {
+         { "Low (30)",           NULL },
          { "Smooth (60)",        NULL },
          { "Ultra Smooth (120)", NULL },
          { "Original (60/30)",   NULL },

--- a/src/main/libretro/libretro_core_options.h
+++ b/src/main/libretro/libretro_core_options.h
@@ -137,7 +137,11 @@ struct retro_core_option_v2_definition option_defs_us[] = {
          { "Original (60/30)",   NULL },
          { NULL, NULL },
       },
+#ifdef LOW_FPS
+      "Low (30)"
+#else
       "Smooth (60)"
+#endif
    },
    {
       "cannonball_video_widescreen",

--- a/src/main/libretro/lr_options.cpp
+++ b/src/main/libretro/lr_options.cpp
@@ -60,6 +60,9 @@ namespace lr_options
 
       switch (val)
       {
+         case 0:
+            strlcpy(str, "Low (30)", len);
+            break;
          case 1:
             strlcpy(str, "Original (60/30)", len);
             break;

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -367,6 +367,8 @@ static void update_variables(bool startup)
          newval = 3;
       else if (strcmp(var.value, "Original (60/30)") == 0)
          newval = 1;
+      else if (strcmp(var.value, "Low (30)") == 0)
+         newval = 0;
       else
          newval = 2;
 
@@ -774,7 +776,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info) {
 
    memset(info, 0, sizeof(*info));
 
-   info->timing.fps            = (config.fps != 120) ? 60 : 119.95;
+   info->timing.fps            = (config.fps != 120) ? config.fps : 119.95;
    info->timing.sample_rate    = 44100;
 
    info->geometry.max_width    = S16_WIDTH_WIDE << 1;
@@ -1162,8 +1164,9 @@ void retro_run(void)
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
         update_variables(false);
 
-    if ((config.fps == 120 && system_av_info.timing.fps == 60) ||
-        (config.fps != 120 && system_av_info.timing.fps == 119.95))
+    if ((config.fps != system_av_info.timing.fps) &&
+        ((config.fps == 120 && system_av_info.timing.fps != 119.95) ||
+         (config.fps != 120 && system_av_info.timing.fps == 119.95)))
         update_timing();
 
     frame++;

--- a/src/main/libretro/main.cpp
+++ b/src/main/libretro/main.cpp
@@ -75,7 +75,11 @@ static void config_init(void)
     config.video.mode       = 0; // Video Mode: Default is Windowed
     config.video.scale      = 1; // Video Scale: Default is 2x
     config.video.scanlines  = 0; // Scanlines
+#ifdef LOW_FPS
+    config.video.fps        = 0; // Default is 30 fps
+#else
     config.video.fps        = 2; // Default is 60 fps
+#endif
     config.video.fps_count  = 0; // FPS Counter
 #ifdef DINGUX
     config.video.widescreen = 0; // Enable Widescreen Mode


### PR DESCRIPTION
Reintroduce 30fps configuration for slower platforms and add Miyoo, defaulting it to 30fps, which it just about copes with.