### PR TITLE
Set the C++17 standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ ifneq (,$(findstring unix,$(platform)))
       endif
    endif
 
+   CXXFLAGS += --std=c++17
+
 # OS X
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib


### PR DESCRIPTION
Code does not compile with -std=c++20 so set the standard to c++17 for Unix platforms.
- fixes #40 as workaround