### PR TITLE
Makefile: add SYSTEM_BOOST option to use system Boost instead of vendored deps/boost

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,15 @@ ifneq (,$(findstring unix,$(platform)))
       endif
    endif
 
+   # Use system Boost instead of vendored deps/boost (allow building with --std=c++20)
+   SYSTEM_BOOST ?= 0
+   ifneq ($(SYSTEM_BOOST), 1)
+      CXX17_SUPPORTED := $(shell $(CXX) -std=c++17 -x c++ /dev/null -fsyntax-only 2>/dev/null && echo 1)
+       ifeq ($(CXX17_SUPPORTED), 1)
+          CXXFLAGS += --std=c++17
+       endif
+   endif
+
 # OS X
 else ifeq ($(platform), osx)
    TARGET := $(TARGET_NAME)_libretro.dylib

--- a/Makefile.common
+++ b/Makefile.common
@@ -1,5 +1,8 @@
 LIBRETRO_COMM_DIR := $(CORE_DIR)/deps/libretro-common
-INCFLAGS := -I$(CORE_DIR)/src/main \
+ifeq ($(SYSTEM_BOOST), 1)
+INCFLAGS := -I$(BOOST_INCLUDEDIR)
+endif
+INCFLAGS += -I$(CORE_DIR)/src/main \
 	    -I$(CORE_DIR)/src/main/libretro \
 	    -I$(LIBRETRO_COMM_DIR)/include \
 	    -I$(CORE_DIR)/deps


### PR DESCRIPTION
When building with a system-provided Boost (e.g. in distribution builds), the vendored Boost headers in deps/boost are old and incompatible with -std=c++20 which is the default in GCC 16.

Setting SYSTEM_BOOST=1 will:
- prepend the system BOOST_INCLUDEDIR path before deps/
- skip forcing -std=c++17 which is only needed as a workaround for the vendored headers

The -std=c++17 flag is also guarded by a compiler capability check so it is not applied on toolchains that do not support it.

- properly fixes #40 
- Replaces workaround #41